### PR TITLE
Align blog list thumbnails to top

### DIFF
--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -72,16 +72,16 @@ const items = await Promise.all(
 			}
 
 			/* Right-aligned square thumbnail */
-			.thumb {
-				width: 84px;
-				height: 84px;
-				border-radius: 14px;
-				overflow: hidden;
-				flex-shrink: 0;
-				/* Center thumbnail vertically within the grid row */
-				align-self: center;
-				border: 1px solid rgba(0, 0, 0, 0.08);
-			}
+                        .thumb {
+                                width: 84px;
+                                height: 84px;
+                                border-radius: 14px;
+                                overflow: hidden;
+                                flex-shrink: 0;
+                                /* Align thumbnail with the top of the text block */
+                                align-self: start;
+                                border: 1px solid rgba(0, 0, 0, 0.08);
+                        }
 			.thumb img {
 				width: 100%;
 				height: 100%;


### PR DESCRIPTION
## Summary
- align the blog index thumbnail grid cell to the top of each post entry
- update the CSS comment to reflect the new alignment

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d232f57814832b974f0acc24ed5e32